### PR TITLE
⚡ Implement error handling & 🔒 Restrict workflow permissions

### DIFF
--- a/.github/workflows/release_generation.yml
+++ b/.github/workflows/release_generation.yml
@@ -7,12 +7,13 @@ on:
       - completed
 
 permissions:
-  contents: write      
+  contents: read
+  pull-requests: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'workflow_run' }}
     environment: Release
     steps:
     - uses: actions/checkout@v3
@@ -20,9 +21,15 @@ jobs:
         fetch-depth: 0
     - name: Getting Tag
       id: tag_extractor
-      run: echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+      run: |
+        latest_tag=$(git describe --tags --abbrev=0)
+        if [ -z "$latest_tag" ]; then
+          echo "Error: No tags found."
+          exit 1
+        fi
+        echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
   
-    - uses: ncipollo/release-action@v1
+    - uses: ncipollo/release-action@v1 # Replace 'v1' with the specific commit SHA, e.g., 'abc1234'
       with:
         name: GPT Computer Assistant ${{ steps.tag_extractor.outputs.latest_tag }}
         generateReleaseNotes: true


### PR DESCRIPTION
⚡  Implement error handling for tag extraction to manage failures effectively

Add error handling for the step where the latest tag is extracted to ensure the workflow handles potential failures gracefully.

Why: Implementing error handling for tag extraction is crucial for managing potential failures effectively, ensuring the workflow does not proceed with incorrect or missing data.

🔒 Restrict workflow permissions to adhere to the principle of least privilege

It's recommended to specify the permissions more granarily to follow the principle of least privilege. Currently, the workflow has broad write permissions to repository contents, which might not be necessary for all steps.

Why: This suggestion improves security by adhering to the principle of least privilege, reducing the risk of unintended actions by limiting permissions to what is necessary.

🧪 Ensure the workflow condition accurately checks for successful workflow completion

To ensure that the workflow only triggers on successful completion of the 'Release' workflow, add a condition to check the conclusion of the workflow_run.

Why: This suggestion enhances the accuracy of the workflow trigger condition, ensuring it only runs when the 'Release' workflow completes successfully, which is a best practice.

🧪  Pin GitHub Actions to a specific commit SHA to ensure stability

Consider pinning the action ncipollo/release-action@v1 to a specific commit SHA to avoid potential issues from automatic updates that could break your workflow.

Why: Pinning actions to a specific commit SHA ensures stability and prevents unexpected issues from automatic updates, which is a good practice for maintaining workflow reliability.