### PR TITLE
fix: Resolved anonymization action logic

### DIFF
--- a/src/upsonic/agent/agent.py
+++ b/src/upsonic/agent/agent.py
@@ -1983,6 +1983,22 @@ class Agent(BaseAgent):
             return task, False
         elif result.action_taken in ["REPLACE", "ANONYMIZE"]:
             task.description = result.final_output or task.description
+            # Store transformation map for de-anonymization of LLM response
+            if result.transformation_map:
+                task._anonymization_map = result.transformation_map
+                # Add anonymization notice to the prompt - prepend for visibility
+                anonymization_notice = (
+                    "[PRIVACY MODE ACTIVE: Personal data has been anonymized with random placeholders. "
+                    "Answer the question directly using the placeholder values shown. "
+                    "Do NOT comment on, question, or mention the format of any data.]\n\n"
+                )
+                task.description = anonymization_notice + task.description
+                if self.debug:
+                    from upsonic.utils.printing import debug_log
+                    debug_log(
+                        f"Stored anonymization map with {len(result.transformation_map)} entries for de-anonymization",
+                        "Agent"
+                    )
             return task, True
         
         return task, True

--- a/src/upsonic/safety_engine/__init__.py
+++ b/src/upsonic/safety_engine/__init__.py
@@ -9,6 +9,11 @@ if TYPE_CHECKING:
     from .base import RuleBase, ActionBase, Policy
     from .models import RuleInput, RuleOutput, ActionResult, PolicyInput, PolicyOutput
     from .exceptions import DisallowedOperation
+    from .anonymization import (
+        anonymize_content, anonymize_contents,
+        deanonymize_content, deanonymize_contents,
+        Anonymizer, AnonymizationResult
+    )
     from .policies import *
 
 def _get_base_classes():
@@ -39,6 +44,23 @@ def _get_exception_classes():
     
     return {
         'DisallowedOperation': DisallowedOperation,
+    }
+
+def _get_anonymization_classes():
+    """Lazy import of anonymization utilities."""
+    from .anonymization import (
+        anonymize_content, anonymize_contents,
+        deanonymize_content, deanonymize_contents,
+        Anonymizer, AnonymizationResult
+    )
+    
+    return {
+        'anonymize_content': anonymize_content,
+        'anonymize_contents': anonymize_contents,
+        'deanonymize_content': deanonymize_content,
+        'deanonymize_contents': deanonymize_contents,
+        'Anonymizer': Anonymizer,
+        'AnonymizationResult': AnonymizationResult,
     }
 
 def _get_policy_classes():
@@ -409,6 +431,10 @@ def __getattr__(name: str) -> Any:
     if name in exception_classes:
         return exception_classes[name]
     
+    anonymization_classes = _get_anonymization_classes()
+    if name in anonymization_classes:
+        return anonymization_classes[name]
+    
     policy_classes = _get_policy_classes()
     if name in policy_classes:
         return policy_classes[name]
@@ -427,6 +453,14 @@ __all__ = [
     "PolicyInput",
     "PolicyOutput",
     "DisallowedOperation",
+    
+    # Anonymization utilities
+    "anonymize_content",
+    "anonymize_contents",
+    "deanonymize_content",
+    "deanonymize_contents",
+    "Anonymizer",
+    "AnonymizationResult",
     
     # Original policies
     "AdultContentBlockPolicy",

--- a/src/upsonic/safety_engine/anonymization.py
+++ b/src/upsonic/safety_engine/anonymization.py
@@ -1,0 +1,313 @@
+"""
+Anonymization Utilities for Safety Engine
+
+This module provides standardized functions for:
+- Anonymizing sensitive data (PII, etc.) with random values before sending to LLM
+- De-anonymizing LLM responses before returning to user
+
+The anonymization uses random character replacement while preserving format:
+- Digits are replaced with random digits
+- Letters are replaced with random letters  
+- Special characters are preserved
+
+Usage:
+    from upsonic.safety_engine.anonymization import (
+        anonymize_content,
+        deanonymize_content,
+        AnonymizationResult
+    )
+    
+    # Anonymize sensitive data
+    result = anonymize_content(
+        content="My email is john@example.com",
+        triggered_keywords=["EMAIL:john@example.com"]
+    )
+    # result.anonymized_content = "My email is xkqp@fhsmwtr.lzn"
+    
+    # Send to LLM...
+    llm_response = "Your email is xkqp@fhsmwtr.lzn"
+    
+    # De-anonymize the response
+    original_response = deanonymize_content(
+        content=llm_response,
+        transformation_map=result.transformation_map
+    )
+    # Result: "Your email is john@example.com"
+"""
+
+import random
+import string
+import re
+from typing import Dict, List, Optional
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AnonymizationResult:
+    """Result of anonymization operation"""
+    anonymized_content: str
+    transformation_map: Dict[int, Dict[str, str]] = field(default_factory=dict)
+    anonymized_count: int = 0
+
+
+class Anonymizer:
+    """
+    Handles reversible anonymization of sensitive content with random values.
+    
+    Replaces sensitive data with random characters while preserving format:
+    - Digits are replaced with random digits
+    - Letters are replaced with random letters
+    - Special characters are preserved
+    """
+    
+    def __init__(self):
+        self._counter = 0
+        self._transformation_map: Dict[int, Dict[str, str]] = {}
+        self._anonymized_cache: Dict[str, str] = {}
+    
+    def reset(self):
+        """Reset the anonymizer state"""
+        self._counter = 0
+        self._transformation_map = {}
+        self._anonymized_cache = {}
+    
+    @property
+    def transformation_map(self) -> Dict[int, Dict[str, str]]:
+        """Get the current transformation map"""
+        return self._transformation_map.copy()
+    
+    def _get_value_from_keyword(self, keyword: str) -> Optional[str]:
+        """
+        Extract value from a triggered keyword.
+        
+        Args:
+            keyword: Triggered keyword like "EMAIL:john@example.com" or plain value
+            
+        Returns:
+            The value to anonymize, or None if should be skipped
+        """
+        if keyword.startswith("PII_KEYWORD:"):
+            return None  # Skip keyword indicators
+        
+        if ":" in keyword:
+            return keyword.split(":", 1)[1]
+        return keyword
+    
+    def _generate_random_replacement(self, original: str) -> str:
+        """
+        Generate a random replacement preserving character types.
+        
+        Args:
+            original: Original string to anonymize
+            
+        Returns:
+            Random replacement with same format
+        """
+        if original in self._anonymized_cache:
+            return self._anonymized_cache[original]
+        
+        replacement = ""
+        for char in original:
+            if char.isdigit():
+                replacement += str(random.randint(0, 9))
+            elif char.isalpha():
+                if char.isupper():
+                    replacement += random.choice(string.ascii_uppercase)
+                else:
+                    replacement += random.choice(string.ascii_lowercase)
+            else:
+                replacement += char
+        
+        self._counter += 1
+        self._transformation_map[self._counter] = {
+            "original": original,
+            "anonymous": replacement
+        }
+        self._anonymized_cache[original] = replacement
+        
+        return replacement
+    
+    def anonymize(self, content: str, triggered_keywords: List[str]) -> AnonymizationResult:
+        """
+        Anonymize content by replacing triggered keywords with random values.
+        
+        Args:
+            content: Original content to anonymize
+            triggered_keywords: List of keywords to anonymize
+            
+        Returns:
+            AnonymizationResult with anonymized content and transformation map
+        """
+        anonymized_content = content
+        anonymized_count = 0
+        
+        for keyword in triggered_keywords:
+            value = self._get_value_from_keyword(keyword)
+            if not value:
+                continue
+            
+            replacement = self._generate_random_replacement(value)
+            
+            pattern = re.compile(re.escape(value), re.IGNORECASE)
+            new_content = pattern.sub(replacement, anonymized_content)
+            
+            if new_content != anonymized_content:
+                anonymized_count += 1
+                anonymized_content = new_content
+        
+        return AnonymizationResult(
+            anonymized_content=anonymized_content,
+            transformation_map=self.transformation_map,
+            anonymized_count=anonymized_count
+        )
+    
+    def anonymize_multiple(
+        self,
+        contents: List[str],
+        triggered_keywords: List[str]
+    ) -> tuple[List[str], Dict[int, Dict[str, str]]]:
+        """
+        Anonymize multiple content strings with consistent mappings.
+        """
+        anonymized_contents = []
+        for content in contents:
+            result = self.anonymize(content, triggered_keywords)
+            anonymized_contents.append(result.anonymized_content)
+        return anonymized_contents, self.transformation_map
+
+
+def anonymize_content(
+    content: str,
+    triggered_keywords: List[str],
+    existing_map: Optional[Dict[int, Dict[str, str]]] = None
+) -> AnonymizationResult:
+    """
+    Anonymize sensitive content with random values.
+    
+    Args:
+        content: The content to anonymize
+        triggered_keywords: List of detected sensitive keywords 
+        existing_map: Optional existing transformation map to extend
+        
+    Returns:
+        AnonymizationResult with anonymized content and transformation_map
+    """
+    anonymizer = Anonymizer()
+    
+    if existing_map:
+        anonymizer._transformation_map = existing_map.copy()
+        anonymizer._counter = max(existing_map.keys()) if existing_map else 0
+        for entry in existing_map.values():
+            anonymizer._anonymized_cache[entry["original"]] = entry["anonymous"]
+    
+    return anonymizer.anonymize(content, triggered_keywords)
+
+
+def anonymize_contents(
+    contents: List[str],
+    triggered_keywords: List[str],
+    existing_map: Optional[Dict[int, Dict[str, str]]] = None
+) -> tuple[List[str], Dict[int, Dict[str, str]]]:
+    """
+    Anonymize multiple content strings with consistent mappings.
+    """
+    anonymizer = Anonymizer()
+    
+    if existing_map:
+        anonymizer._transformation_map = existing_map.copy()
+        anonymizer._counter = max(existing_map.keys()) if existing_map else 0
+        for entry in existing_map.values():
+            anonymizer._anonymized_cache[entry["original"]] = entry["anonymous"]
+    
+    return anonymizer.anonymize_multiple(contents, triggered_keywords)
+
+
+def deanonymize_content(
+    content: str,
+    transformation_map: Dict[int, Dict[str, str]]
+) -> str:
+    """
+    De-anonymize content by replacing anonymous values with originals.
+    
+    This reverses the anonymization process, converting anonymous
+    placeholders back to their original values.
+    
+    Args:
+        content: Content with anonymous placeholders
+        transformation_map: Map from anonymize_content() containing original values
+        
+    Returns:
+        Content with original values restored
+        
+    Example:
+        >>> transformation_map = {
+        ...     1: {"original": "john@example.com", "anonymous": "anon001@anonymized.local"}
+        ... }
+        >>> deanonymize_content(
+        ...     "Your email is anon001@anonymized.local",
+        ...     transformation_map
+        ... )
+        "Your email is john@example.com"
+    """
+    if not transformation_map:
+        return content
+    
+    result = content
+    
+    # Sort by anonymous value length (longest first) to avoid partial replacements
+    sorted_entries = sorted(
+        transformation_map.values(),
+        key=lambda x: len(x.get("anonymous", "")),
+        reverse=True
+    )
+    
+    for entry in sorted_entries:
+        anonymous = entry.get("anonymous", "")
+        original = entry.get("original", "")
+        
+        if anonymous and original:
+            # Case-insensitive replacement
+            pattern = re.compile(re.escape(anonymous), re.IGNORECASE)
+            result = pattern.sub(original, result)
+    
+    return result
+
+
+def deanonymize_contents(
+    contents: List[str],
+    transformation_map: Dict[int, Dict[str, str]]
+) -> List[str]:
+    """
+    De-anonymize multiple content strings.
+    
+    Args:
+        contents: List of content strings with anonymous placeholders
+        transformation_map: Map containing original values
+        
+    Returns:
+        List of contents with original values restored
+    """
+    return [deanonymize_content(content, transformation_map) for content in contents]
+
+
+# Convenience function for ActionBase integration
+def create_anonymization_result(
+    original_content: List[str],
+    triggered_keywords: List[str],
+    use_random_format: bool = False
+) -> tuple[List[str], Dict[int, Dict[str, str]]]:
+    """
+    Create anonymization result for ActionBase integration.
+    
+    This is designed to be called from ActionBase subclasses to
+    provide a standardized anonymization interface.
+    
+    Args:
+        original_content: List of original content strings
+        triggered_keywords: List of triggered keywords from rule
+        use_random_format: Use random character replacement
+        
+    Returns:
+        Tuple of (anonymized_contents, transformation_map)
+    """
+    return anonymize_contents(original_content, triggered_keywords, use_random_format)

--- a/src/upsonic/safety_engine/policies/pii_policies.py
+++ b/src/upsonic/safety_engine/policies/pii_policies.py
@@ -306,10 +306,10 @@ class PIIBlockAction_LLM(ActionBase):
 
 
 class PIIAnonymizeAction(ActionBase):
-    """Action to anonymize PII content"""
+    """Action to anonymize PII content with reversible unique replacements"""
     
     name = "PII Anonymize Action"
-    description = "Anonymizes personal identifiable information while preserving content structure"
+    description = "Anonymizes personal identifiable information with reversible unique replacements"
     language = "en"
     
     def action(self, rule_result: RuleOutput) -> PolicyOutput:
@@ -318,85 +318,8 @@ class PIIAnonymizeAction(ActionBase):
         if rule_result.confidence < 0.3:
             return self.allow_content()
         
-        return self._anonymize_pii_with_specific_format()
-    
-    def _anonymize_pii_with_specific_format(self) -> PolicyOutput:
-        """Anonymize PII with specific format: email -> xxxx@xxxxxxx.xxx, phone -> XXX-XXXX"""
-        original_content = self.original_content or []
-        triggered_keywords = self.rule_result.triggered_keywords if self.rule_result else []
-        
-        transformed_content = []
-        for text in original_content:
-            transformed_text = text
-            
-            for keyword in triggered_keywords:
-                if keyword.startswith("EMAIL:"):
-                    # Extract the actual email from "EMAIL:john@example.com"
-                    email = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(email, "xxxx@xxxxxxx.xxx")
-                    
-                elif keyword.startswith("PHONE:"):
-                    # Extract the actual phone from "PHONE:555-0123"
-                    phone = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(phone, "XXX-XXXX")
-                    
-                elif keyword.startswith("SSN:"):
-                    # Extract the actual SSN from "SSN:123-45-6789"
-                    ssn = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(ssn, "XXX-XX-XXXX")
-                    
-                elif keyword.startswith("CREDIT_CARD:"):
-                    # Extract the actual credit card from "CREDIT_CARD:1234-5678-9012-3456"
-                    cc = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(cc, "XXXX-XXXX-XXXX-XXXX")
-                    
-                elif keyword.startswith("ADDRESS:"):
-                    # Extract the actual address from "ADDRESS:123 Main St"
-                    address = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(address, "[ADDRESS_REDACTED]")
-                    
-                elif keyword.startswith("DOB:"):
-                    # Extract the actual DOB from "DOB:01/01/1990"
-                    dob = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(dob, "XX/XX/XXXX")
-                    
-                elif keyword.startswith("DRIVERS_LICENSE:"):
-                    # Extract the actual DL from "DRIVERS_LICENSE:ABC123456"
-                    dl = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(dl, "XXX-XXXXXX")
-                    
-                elif keyword.startswith("PASSPORT:"):
-                    # Extract the actual passport from "PASSPORT:AB1234567"
-                    passport = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(passport, "XX-XXXXXXX")
-                    
-                elif keyword.startswith("IP_ADDRESS:"):
-                    # Extract the actual IP from "IP_ADDRESS:192.168.1.1"
-                    ip = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(ip, "XXX.XXX.XXX.XXX")
-                    
-                elif keyword.startswith("MAC_ADDRESS:"):
-                    # Extract the actual MAC from "MAC_ADDRESS:AA:BB:CC:DD:EE:FF"
-                    mac = keyword.split(":", 1)[1]
-                    transformed_text = transformed_text.replace(mac, "XX:XX:XX:XX:XX:XX")
-                    
-                elif keyword.startswith("PII_KEYWORD:"):
-                    # For PII keywords, we don't need to replace anything as they're just indicators
-                    pass
-            
-            transformed_content.append(transformed_text)
-        
-        translated_message = self._translate("PII anonymized with specific format", self.detected_language)
-        
-        return PolicyOutput(
-            output_texts=transformed_content,
-            action_output={
-                "action_taken": "ANONYMIZE",
-                "success": True,
-                "message": translated_message
-            },
-            transformation_map=self.transformation_map.copy()
-        )
+        # Use the standardized anonymization utility
+        return self.anonymize_triggered_keywords()
 
 
 class PIIReplaceAction(ActionBase):

--- a/src/upsonic/tasks/tasks.py
+++ b/src/upsonic/tasks/tasks.py
@@ -54,6 +54,11 @@ class Task(BaseModel):
 
     _task_todos: Optional[Any] = None
     
+    # Anonymization map for reversible PII protection
+    # Stores mappings: {idx: {"original": "...", "anonymous": "...", "pii_type": "..."}}
+    # Used to de-anonymize LLM responses before returning to user
+    _anonymization_map: Optional[Dict[int, Dict[str, str]]] = None
+    
     registered_task_tools: Dict[str, Any] = {}
     task_builtin_tools: List[Any] = []
         


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the privacy/anonymization flow by transforming user prompts and post-processing model outputs, so mistakes could leak PII or corrupt returned content (especially for structured/Pydantic outputs). Changes are localized but affect all runs when anonymization triggers.
> 
> **Overview**
> Adds **reversible anonymization** support end-to-end: safety policies can now return a `transformation_map`, which is stored on the `Task` when user input is `REPLACE`/`ANONYMIZE` and accompanied by a privacy-mode notice prepended to the prompt.
> 
> Introduces `safety_engine.anonymization` utilities and exports them from `safety_engine.__init__`, updates `PolicyResult`/`PolicyManager` to aggregate transformation maps across policies, and updates `FinalizationStep` to **de-anonymize** the final `context.output` (and best-effort structured/Pydantic outputs) plus `task._response` before returning to the caller.
> 
> Simplifies `PIIAnonymizeAction` to use the standardized anonymization path and hardens `ActionBase.anonymize_triggered_keywords` to skip `PII_KEYWORD:` markers and handle typed keywords consistently (case-insensitive regex replacement).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 008cdcb1611918a669beae342d3b4f1e5f0894b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->