### PR TITLE
docs: fix test command in CONTRIBUTING.md to use uv run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ uv pip install -e ".[vectordb,storage,models,embeddings,tools]"
 
 ### Unit Tests
 ```bash
-pytest tests/unit_tests -v
+uv run --all-extras pytest tests/unit_tests -v
 ```
 
 ### Smoke Tests (requires Docker)
@@ -42,8 +42,8 @@ This will automatically start the required Docker services (Redis, PostgreSQL, M
 
 ### Running Specific Tests
 ```bash
-pytest tests/unit_tests/tools/test_common_tools_duckduckgo.py -v
-pytest tests/smoke_tests/memory -v
+uv run --all-extras pytest tests/unit_tests/tools/test_common_tools_duckduckgo.py -v
+uv run --all-extras pytest tests/smoke_tests/memory -v
 ```
 
 ## Code Standards


### PR DESCRIPTION
- Fixed CONTRIBUTING.md test commands: Commands were missing `uv run --all-extras` prefix.

Full Changelog: https://github.com/Upsonic/Upsonic/compare/master...upsonic/contributing-test-command

### Pull Request:
- [made-by Irem Oztimur](https://github.com/IremOztimur) in [#520](https://github.com/Upsonic/Upsonic/pull/520)