### PR TITLE
vectordb: hardening pgvector provider against potential SQL injection

### DIFF
--- a/src/upsonic/vectordb/config.py
+++ b/src/upsonic/vectordb/config.py
@@ -473,7 +473,20 @@ class PgVectorConfig(BaseVectorDBConfig):
     pool_timeout: float = 30.0
     pool_recycle: int = 3600
     
-    @pydantic.field_validator('table_name')
+    @pydantic.field_validator('schema_name', 'table_name')
+    @classmethod
+    def validate_identifiers(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure schema and table names are safe SQL identifiers."""
+        if v is not None:
+            import re
+            if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', v):
+                raise ValueError(
+                    f"Invalid SQL identifier: '{v}'. "
+                    "Only alphanumeric characters and underscores are allowed."
+                )
+        return v
+
+    @pydantic.field_validator('table_name', mode='before')
     @classmethod
     def set_table_name(cls, v, info):
         """Use collection_name as table_name if not specified."""

--- a/src/upsonic/vectordb/providers/pgvector.py
+++ b/src/upsonic/vectordb/providers/pgvector.py
@@ -492,8 +492,9 @@ class PgVectorProvider(BaseVectorDBProvider):
                         # Create schema
                         if self.schema_name and self.schema_name != "public":
                             logger.debug(f"Creating schema: {self.schema_name}")
+                            # Quote schema name to prevent injection
                             session.execute(
-                                text(f"CREATE SCHEMA IF NOT EXISTS {self.schema_name};")
+                                text(f'CREATE SCHEMA IF NOT EXISTS "{self.schema_name}";')
                             )
                 
                 # Create table
@@ -1728,7 +1729,7 @@ class PgVectorProvider(BaseVectorDBProvider):
         
         create_sql = text(
             f'CREATE INDEX "{self._vector_index_name}" '
-            f'ON {self.schema_name}.{self.table_name} '
+            f'ON "{self.schema_name}"."{self.table_name}" '
             f'USING hnsw (embedding {distance_op}) '
             f'WITH (m = {m_val}, ef_construction = {ef_val});'
         )
@@ -1750,7 +1751,7 @@ class PgVectorProvider(BaseVectorDBProvider):
         
         create_sql = text(
             f'CREATE INDEX "{self._vector_index_name}" '
-            f'ON {self.schema_name}.{self.table_name} '
+            f'ON "{self.schema_name}"."{self.table_name}" '
             f'USING ivfflat (embedding {distance_op}) '
             f'WITH (lists = {lists_val});'
         )
@@ -1808,7 +1809,7 @@ class PgVectorProvider(BaseVectorDBProvider):
                         safe_language = ''.join(c for c in language if c.isalnum() or c == '_')
                         create_sql = text(
                             f'CREATE INDEX "{self._gin_index_name}" '
-                            f'ON {self.schema_name}.{self.table_name} '
+                            f'ON "{self.schema_name}"."{self.table_name}" '
                             f"USING GIN (to_tsvector('{safe_language}', content));"
                         )
                         session.execute(create_sql)
@@ -1836,7 +1837,7 @@ class PgVectorProvider(BaseVectorDBProvider):
                         logger.debug("Creating GIN index for metadata")
                         create_sql = text(
                             f'CREATE INDEX "{metadata_index_name}" '
-                            f'ON {self.schema_name}.{self.table_name} '
+                            f'ON "{self.schema_name}"."{self.table_name}" '
                             f'USING GIN (metadata);'
                         )
                         session.execute(create_sql)


### PR DESCRIPTION
Added Pydantic validation for table and schema names in PgVectorConfig to ensure they only contain alphanumeric characters and underscores. Additionally, I updated the PgVector provider to use double quotes for all DDL statements (CREATE SCHEMA, CREATE INDEX) involving user-supplied identifiers. While these values usually come from configuration, these changes provide an important layer of defense when collection names are dynamically generated by agents.