### PR TITLE
fix: prevent command injection in check_command_exists (CWE-78)

### DIFF
--- a/src/upsonic/agent/autonomous_agent/shell_toolkit.py
+++ b/src/upsonic/agent/autonomous_agent/shell_toolkit.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -318,15 +319,9 @@ class AutonomousShellToolKit(ToolKit):
         Returns:
             Information about the command availability
         """
-        result = subprocess.run(
-            f"which {command}",
-            shell=True,
-            capture_output=True,
-            text=True,
-        )
-        
-        if result.returncode == 0:
-            return f"✅ Command '{command}' is available at: {result.stdout.strip()}"
+        path = shutil.which(command)
+        if path is not None:
+            return f"✅ Command '{command}' is available at: {path}"
         else:
             return f"❌ Command '{command}' is not available"
     


### PR DESCRIPTION
## Summary

Fixes #558 — `check_command_exists` used `subprocess.run(f"which {command}", shell=True)` which allowed arbitrary command execution via shell metacharacters.

## Changes

- Replaced `subprocess.run(f"which {command}", shell=True, ...)` with `shutil.which(command)`
- Added `import shutil` at the top of the file
- The `shutil.which()` function is a pure Python implementation that searches PATH without invoking a shell, making it immune to command injection

## CWE Reference

- **CWE-78**: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
- **Severity**: High

## Testing

- Verify that `check_command_exists("python3")` still correctly reports the command as available
- Verify that `check_command_exists("foo; echo pwned")` reports the command as unavailable (not executing the injected command)
- Verify that `check_command_exists("nonexistent")` reports the command as unavailable

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*