### PR TITLE
feat: rename AppliedScientist research_paper to research_source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "examples"]
 	path = examples
 	url = https://github.com/Upsonic/Examples.git
+[submodule "Docs"]
+	path = Docs
+	url = https://github.com/Upsonic/Docs.git

--- a/prebuilt_autonomous_agents/applied_scientist/first_message.md
+++ b/prebuilt_autonomous_agents/applied_scientist/first_message.md
@@ -1,12 +1,14 @@
 New experiment.
 
 **Experiment name:** {research_name}
-**Research paper:** {research_paper}
+**Research source:** {research_source}
 **Current notebook:** {current_notebook}
 **Current data:** {current_data}
 **Experiments directory:** {experiments_directory}
 
-Use `{research_name}` **exactly as given** for the experiment folder (`{experiments_directory}/{research_name}/`) and for the `"name"` field in every JSON file — do not rename it, do not add suffixes, do not derive a new one from the paper title.
+The research source describes the new method to evaluate. It may be a local file (PDF, Markdown, HTML, notebook), a web URL (blog post, arXiv link, documentation page), a git repository URL, or any other reference you can fetch and read. Detect the type at Phase 0 and materialize it inside the experiment folder before reading it (see `skills/experiment_management/SKILL.md`).
+
+Use `{research_name}` **exactly as given** for the experiment folder (`{experiments_directory}/{research_name}/`) and for the `"name"` field in every JSON file — do not rename it, do not add suffixes, do not derive a new one from the source title.
 
 Run the full experiment pipeline. Go from Phase 0 through Phase 5 without stopping. All bookkeeping is JSON — update `progress.json` continuously and, at the end, write `result.json` with the final verdict, summary, and comparison table. No markdown reports.
 

--- a/prebuilt_autonomous_agents/applied_scientist/skills/evaluate/SKILL.md
+++ b/prebuilt_autonomous_agents/applied_scientist/skills/evaluate/SKILL.md
@@ -58,7 +58,7 @@ Phase 5 — after the new implementation is complete and metrics are collected.
        "current_notebook":   "experiments/{research_name}/current.ipynb",
        "current_data":       "experiments/{research_name}/current_data/",
        "new_notebook":       "experiments/{research_name}/new.ipynb",
-       "research_paper":     "experiments/{research_name}/research.pdf",
+       "research_source":    "experiments/{research_name}/research.pdf",
        "experiment_log":     "experiments/{research_name}/log.json"
      }
    }
@@ -72,7 +72,7 @@ Phase 5 — after the new implementation is complete and metrics are collected.
      - `diff = new - current` (raw number). `diff_display` is the short string with sign (`"+0.019"`, `"-0.03"`).
      - `better`: `"new"` | `"current"` | `"tie"` | `null` — computed from `diff` and `higher_is_better`.
      - `unit` is a short unit string (`"seconds"`, `"%"`, etc.) or `null`.
-   - `file_locations` uses paths relative to the experiments directory root.
+   - `file_locations` uses paths relative to the experiments directory root. `research_source` must match whatever Phase 0 materialized — `research.pdf`, `research_source.{ext}`, or the `research_source/` directory for a cloned repo.
 
 4. **Update `experiments/experiments.json`:**
    - Set `status` to `"completed"` (or `"failed"` if the experiment failed).

--- a/prebuilt_autonomous_agents/applied_scientist/skills/experiment_management/SKILL.md
+++ b/prebuilt_autonomous_agents/applied_scientist/skills/experiment_management/SKILL.md
@@ -10,8 +10,8 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
 ## Input
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| research_name | string | The experiment name **as given by the caller**. Use it verbatim — do not rename it, do not re-derive it from the paper title. |
-| research_paper | path | Path to the PDF paper |
+| research_name | string | The experiment name **as given by the caller**. Use it verbatim — do not rename it, do not re-derive it from the source title. |
+| research_source | ref | A reference describing the new method. Any of: local file path (PDF, Markdown, HTML, `.ipynb`, …), web URL (blog post, arXiv, docs), git repository URL, Kaggle notebook or dataset page, or another fetchable resource. |
 | current_notebook | path | Path to the current baseline .ipynb |
 | current_data | path | Path to the current dataset (file or directory) |
 | experiments_directory | path | The directory (inside the workspace) where experiment folders live (e.g. `./experiments`). |
@@ -25,24 +25,39 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
    experiments/{research_name}/
    ```
 
-2. **Copy files (NEVER move, NEVER modify originals):**
+2. **Copy baseline files (NEVER move, NEVER modify originals):**
    ```bash
    cp {current_notebook} experiments/{research_name}/current.ipynb
    cp -r {current_data}  experiments/{research_name}/current_data/
-   cp {research_paper}   experiments/{research_name}/research.pdf
    ```
 
    If `current_data` is a code-based download (e.g. `fetch_ucirepo(id=2)`), leave `current_data/` empty and record the download spec in `log.json`'s metadata.
 
-3. **Create `log.json`** with the starting skeleton:
+3. **Materialize the research source.** Detect the kind of `{research_source}` and save a local copy inside the experiment folder:
+
+   | Kind | Detection | Command / action | Local path |
+   |---|---|---|---|
+   | Local PDF | existing path, `.pdf` extension | `cp {research_source} experiments/{research_name}/research.pdf` | `research.pdf` |
+   | Other local file | existing path, non-PDF (`.md`, `.html`, `.txt`, `.ipynb`, …) | `cp {research_source} experiments/{research_name}/research_source.{ext}` | `research_source.{ext}` |
+   | Git repository | `git@…`, ends in `.git`, or known git host (`github.com`, `gitlab.com`, `bitbucket.org`, …) | `git clone --depth 1 {research_source} experiments/{research_name}/research_source/` | `research_source/` |
+   | Kaggle notebook | `https://www.kaggle.com/code/<user>/<slug>` (or legacy `/kernels/…`) | if the Kaggle CLI is installed and authenticated: `kaggle kernels pull <user>/<slug> -p experiments/{research_name}/research_source/`. Otherwise fall back to fetching the page HTML. | `research_source/` |
+   | Kaggle dataset | `https://www.kaggle.com/datasets/<user>/<slug>` | if the Kaggle CLI is installed and authenticated: `kaggle datasets download -d <user>/<slug> -p experiments/{research_name}/research_source/ --unzip`. Otherwise save the page HTML. | `research_source/` |
+   | Web URL | `http(s)://` and not matched above | fetch the page (e.g. `curl -L -o research_source.html {research_source}`). If the URL clearly points at a PDF (e.g. arXiv `/pdf/...` link), save as `research.pdf`. Optionally also save a cleaned Markdown version as `research_source.md`. | `research_source.html` (or `research.pdf` / `research_source.md`) |
+   | Other | fallback | fetch and save a readable local copy; document the choice in `log.json.metadata` | as chosen |
+
+   Let `research_source_local` be whichever local path you produced. Use that path for Phase 2 onwards — never re-fetch.
+
+4. **Create `log.json`** with the starting skeleton:
    ```json
    {
      "name": "{research_name}",
      "metadata": {
        "date": "YYYY-MM-DD",
-       "original_notebook": "{current_notebook}",
-       "original_data":     "{current_data}",
-       "research_paper":    "{research_paper}"
+       "original_notebook":      "{current_notebook}",
+       "original_data":          "{current_data}",
+       "research_source":        "{research_source_local}",
+       "research_source_origin": "{research_source}",
+       "research_source_kind":   "pdf | file | git | kaggle_notebook | kaggle_dataset | web | other"
      },
      "phases": []
    }

--- a/prebuilt_autonomous_agents/applied_scientist/skills/research/SKILL.md
+++ b/prebuilt_autonomous_agents/applied_scientist/skills/research/SKILL.md
@@ -1,7 +1,7 @@
 # Research Skill
 
 ## Purpose
-Read a research paper and extract actionable information needed to implement the proposed method. Record the findings as a structured JSON entry.
+Read the materialized research source and extract actionable information needed to implement the proposed method. Record the findings as a structured JSON entry.
 
 ## When to Use
 Phase 2 — after the current implementation has been analyzed.
@@ -11,9 +11,19 @@ Phase 2 — after the current implementation has been analyzed.
 |-----------|------|-------------|
 | experiment_path | path | `experiments/{research_name}/` |
 
+The research source was materialized into `{experiment_path}` during Phase 0. Its local path is recorded in `{experiment_path}/log.json` under `metadata.research_source`, and its kind (`pdf`, `file`, `git`, `kaggle_notebook`, `kaggle_dataset`, `web`, `other`) under `metadata.research_source_kind`. Expected layouts:
+
+- `pdf` → `{experiment_path}/research.pdf`
+- `file` → `{experiment_path}/research_source.{ext}` (Markdown, HTML, `.ipynb`, text, …)
+- `git` → `{experiment_path}/research_source/` (cloned repository — read `README*`, `docs/`, the top-level code, and any papers/notebooks inside)
+- `kaggle_notebook` → `{experiment_path}/research_source/` (pulled Kaggle kernel — read the `.ipynb` and any accompanying metadata; fall back to the saved HTML if the CLI was unavailable)
+- `kaggle_dataset` → `{experiment_path}/research_source/` (downloaded Kaggle dataset — read the dataset description / README and skim files to understand the data; fall back to the saved HTML if the CLI was unavailable)
+- `web` → `{experiment_path}/research_source.html` (and possibly `research_source.md` or `research.pdf`)
+- `other` → whatever Phase 0 saved (check `metadata.research_source`)
+
 ## Actions
 
-1. **Read `{experiment_path}/research.pdf`** and extract:
+1. **Read the materialized research source** at `metadata.research_source` (falling back to `research.pdf` for legacy experiments) and extract:
 
    - **Method Summary:** 2-3 short paragraphs describing what the paper proposes, what problem it solves, and how it differs from traditional approaches.
    - **Pros:** each advantage the paper claims or demonstrates.

--- a/prebuilt_autonomous_agents/applied_scientist/system_prompt.md
+++ b/prebuilt_autonomous_agents/applied_scientist/system_prompt.md
@@ -12,7 +12,7 @@ In the real world, a data scientist reads a paper, gets excited, spends days imp
 
 An **experiment** is the full cycle of:
 1. Understanding what we currently have (a trained model, a notebook, a dataset)
-2. Understanding what's being proposed (a research paper with a new method)
+2. Understanding what's being proposed (a research source — a paper, blog post, docs page, git repo, or any other reference describing a new method)
 3. Implementing the proposed method on the same data
 4. Comparing the two fairly and reporting the result
 
@@ -48,13 +48,29 @@ You will receive exactly five things:
 
 | Input | What It Is | Example |
 |---|---|---|
-| `research_name` | The exact folder name and JSON `"name"` to use for this experiment. **Use it verbatim** — do not derive a new one from the paper, do not add suffixes, do not rename it. | `tabpfn_adult` |
-| `research_paper` | A PDF file containing a research paper that proposes a new method | `example_1/tabpfn.pdf` |
+| `research_name` | The exact folder name and JSON `"name"` to use for this experiment. **Use it verbatim** — do not derive a new one from the source, do not add suffixes, do not rename it. | `tabpfn_adult` |
+| `research_source` | Any reference that describes the new method. Accepted forms: local file (PDF, Markdown, HTML, .ipynb, text), web URL (blog post, arXiv, documentation), git repository URL (`https://…/repo.git` or `git@…`), Kaggle notebook or dataset page, or any other fetchable resource. | `example_1/tabpfn.pdf`, `https://arxiv.org/abs/2207.01848`, `https://github.com/automl/TabPFN`, `https://www.kaggle.com/code/<user>/<slug>` |
 | `current_notebook` | A Jupyter notebook (.ipynb) with the current baseline implementation | `example_1/Baseline XGBoost Adult.ipynb` |
 | `current_data` | The dataset used by the current notebook (file or directory) | `example_1/data/` or downloaded via code in notebook |
 | `experiments_directory` | The directory inside your workspace where experiment folders live | `./experiments` |
 
 The experiment folder is always `{experiments_directory}/{research_name}/`. If the current notebook downloads its data programmatically (e.g., from `ucimlrepo` or `sklearn.datasets`), record that in `log.json`'s metadata and make sure the new notebook uses the exact same download logic.
+
+### Research source handling
+
+At Phase 0 you must inspect `research_source` and materialize it inside the experiment folder. The resulting path is what Phase 2 (`research` skill) reads from, and what you record in `log.json.metadata.research_source` and `result.json.file_locations.research_source`.
+
+| Source type | How to detect | How to materialize | Local path |
+|---|---|---|---|
+| Local PDF | existing path ending in `.pdf` | `cp {research_source} experiments/{research_name}/research.pdf` | `research.pdf` |
+| Other local file (`.md`, `.html`, `.txt`, `.ipynb`, …) | existing path with a non-PDF extension | copy preserving extension | `research_source.{ext}` |
+| Git repository URL | starts with `git@`, ends in `.git`, or matches a known git host (`github.com`, `gitlab.com`, `bitbucket.org`, …) | `git clone --depth 1 {research_source} experiments/{research_name}/research_source/` | `research_source/` (directory) |
+| Kaggle notebook URL | `https://www.kaggle.com/code/<user>/<slug>` (or legacy `/kernels/…`) | pull the notebook with the Kaggle CLI when available (`kaggle kernels pull <user>/<slug> -p experiments/{research_name}/research_source/`), otherwise fetch the page HTML. Also save the rendered `.ipynb` if retrievable. | `research_source/` |
+| Kaggle dataset URL | `https://www.kaggle.com/datasets/<user>/<slug>` | download with `kaggle datasets download -d <user>/<slug> -p experiments/{research_name}/research_source/ --unzip` when available, otherwise save the page HTML. | `research_source/` |
+| Web URL (http/https, non-git, non-Kaggle) | URL scheme is `http` / `https` and not matched above | fetch the page; save raw HTML as `research_source.html` and, if useful, a cleaned Markdown version as `research_source.md`. For arXiv abstract URLs, also download the matching PDF to `research.pdf`. | `research_source.html` (+ optional `research.pdf` / `.md`) |
+| Anything else | fallback | do your best to fetch and save a readable local copy; document the choice in `log.json.metadata` | whatever you wrote |
+
+In all cases, once materialized, use only the local path for Phase 2 onwards — never re-fetch during later phases.
 
 ---
 
@@ -90,7 +106,7 @@ This file is the machine-readable answer to the question: "Should we switch to t
     "current_notebook":  "experiments/{research_name}/current.ipynb",
     "current_data":      "experiments/{research_name}/current_data/",
     "new_notebook":      "experiments/{research_name}/new.ipynb",
-    "research_paper":    "experiments/{research_name}/research.pdf",
+    "research_source":   "experiments/{research_name}/research.pdf",
     "experiment_log":    "experiments/{research_name}/log.json"
   }
 }
@@ -100,7 +116,7 @@ This file is the machine-readable answer to the question: "Should we switch to t
 
 ## Experiment Folder Structure
 
-Every experiment produces this exact structure. **No markdown reports** — only notebooks, the PDF, and JSON bookkeeping.
+Every experiment produces this exact structure. **No markdown reports** — only notebooks, the materialized research source, and JSON bookkeeping.
 
 ```
 experiments/
@@ -112,7 +128,9 @@ experiments/
     ├── current_requirements.txt  # Dependencies for the current notebook
     ├── new.ipynb                 # Your new implementation
     ├── new_requirements.txt      # Dependencies for the new implementation
-    ├── research.pdf              # COPY of the paper
+    ├── research.pdf              # Local copy of the research source when it is a PDF …
+    │                             #   or `research_source.{ext}` / `research_source/`
+    │                             #   for non-PDF files, web pages, and git repos.
     ├── log.json                  # Phase-by-phase structured log of everything you did
     ├── progress.json             # Live progress snapshot (overwritten in real-time)
     └── result.json               # The final machine-readable comparison report
@@ -128,8 +146,8 @@ experiments/
 - Create `experiments/{research_name}/` directory
 - COPY the current notebook → `experiments/{research_name}/current.ipynb`
 - COPY the current data → `experiments/{research_name}/current_data/` (skip if code-based; record the download spec in `log.json`)
-- COPY the research paper → `experiments/{research_name}/research.pdf`
-- Initialize `experiments/{research_name}/log.json` with metadata (date, original paths) and an empty `phases: []` array
+- MATERIALIZE the research source into the experiment folder using the table above (PDF → `research.pdf`; other local file → `research_source.{ext}`; git repo → `research_source/`; Kaggle notebook or dataset → `research_source/`; generic web URL → `research_source.html` + optional extras). Record the chosen local path as `metadata.research_source` in `log.json`.
+- Initialize `experiments/{research_name}/log.json` with metadata (date, original paths, `research_source` local path and original reference) and an empty `phases: []` array
 - Initialize `experiments/{research_name}/progress.json` — `status: "RUNNING"`, all phases `pending`, Phase 0 `current`, `started_at` + `updated_at` set
 - Register the experiment in `experiments/experiments.json` with `status: "in_progress"`
 
@@ -150,7 +168,7 @@ After this phase: you know exactly what the baseline does and what numbers it pr
 ### Phase 2: Research (`research` skill)
 **Goal:** Understand the proposed method well enough to implement it.
 
-- Read `experiments/{research_name}/research.pdf`
+- Read the materialized research source inside `experiments/{research_name}/` (the path recorded as `metadata.research_source` in `log.json` — `research.pdf`, `research_source.{ext}`, or the files under `research_source/`)
 - Extract: method summary, pros, cons, requirements
 - Analyze compatibility: can this method use the same data? same metrics? what new dependencies are needed?
 - Append a Phase 2 entry to `log.json`

--- a/src/upsonic/agent/prebuilt_autonomous_agent/prebuilt_autonomous_agent.py
+++ b/src/upsonic/agent/prebuilt_autonomous_agent/prebuilt_autonomous_agent.py
@@ -66,7 +66,7 @@ class PrebuiltAutonomousAgent(AutonomousAgent):
         agent.run_console(
             workspace="./ws",
             inputs=["example_1/"],
-            research_paper="example_1/paper.pdf",
+            research_source="example_1/paper.pdf",
             current_notebook="example_1/baseline.ipynb",
         )
         ```

--- a/src/upsonic/prebuilt/__init__.py
+++ b/src/upsonic/prebuilt/__init__.py
@@ -12,7 +12,8 @@ Usage:
 
     scientist = AppliedScientist(model="openai/gpt-4o", workspace="./ws")
     exp = scientist.new_experiment(
-        research_paper="example_1/tabpfn.pdf",
+        name="tabpfn_adult",
+        research_source="example_1/tabpfn.pdf",          # PDF, web URL, git repo, …
         current_notebook="example_1/baseline.ipynb",
         current_data="downloaded in notebook (ucimlrepo, id=2)",
         experiments_directory="./experiments",

--- a/src/upsonic/prebuilt/upsonic_prebuilt_agents.py
+++ b/src/upsonic/prebuilt/upsonic_prebuilt_agents.py
@@ -213,7 +213,7 @@ class Experiment:
 
         self._thread = threading.Thread(
             target=worker,
-            name=f"Experiment-{self._template_params.get('research_paper', 'run')}",
+            name=f"Experiment-{self._template_params.get('research_source', 'run')}",
             daemon=True,
         )
         self._thread.start()
@@ -992,7 +992,7 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         self,
         name: str,
         *,
-        research_paper: str,
+        research_source: str,
         current_notebook: str,
         current_data: str,
         experiments_directory: Optional[str] = None,
@@ -1005,8 +1005,15 @@ class AppliedScientist(PrebuiltAutonomousAgent):
 
         ``name`` is the exact folder name / ``"name"`` field used by the agent
         in every JSON file it writes. The agent is instructed to use it
-        verbatim — no derivation from the paper title, no suffixes — so
+        verbatim — no derivation from the source title, no suffixes — so
         ``scientist.experiments[name]`` always points at this run.
+
+        ``research_source`` is the material describing the new method. It can
+        be a local PDF path, a web page / blog post URL, a git repository URL,
+        or any other reference the agent can fetch and read (e.g. a Markdown
+        or HTML file path, an arXiv link). The agent detects the source type
+        and materializes it under ``experiments/{research_name}/`` before
+        reading it.
 
         ``experiments_directory`` defaults to the value supplied at
         construction (``"experiments"`` unless overridden). It is always
@@ -1024,7 +1031,7 @@ class AppliedScientist(PrebuiltAutonomousAgent):
             name=name,
             template_params={
                 "research_name": name,
-                "research_paper": research_paper,
+                "research_source": research_source,
                 "current_notebook": current_notebook,
                 "current_data": current_data,
                 "experiments_directory": exp_dir,


### PR DESCRIPTION
Accept any reference describing the new method — local file (PDF, Markdown, HTML, .ipynb, text), web URL, git repo, or Kaggle notebook / dataset page — not just a PDF. The agent detects the source kind at Phase 0 and materializes it into the experiment folder before reading it in Phase 2.

Also add the Upsonic/Docs repository as a submodule at Docs/ so the rename can be kept in lockstep with the public docs.