### PR TITLE
feat: AppliedScientist accepts any research_source + auto inputs

### DIFF
--- a/prebuilt_autonomous_agents/applied_scientist/skills/experiment_management/SKILL.md
+++ b/prebuilt_autonomous_agents/applied_scientist/skills/experiment_management/SKILL.md
@@ -11,7 +11,7 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | research_name | string | The experiment name **as given by the caller**. Use it verbatim — do not rename it, do not re-derive it from the source title. |
-| research_source | ref | A reference describing the new method. Any of: local file path (PDF, Markdown, HTML, `.ipynb`, …), web URL (blog post, arXiv, docs), git repository URL, Kaggle notebook or dataset page, or another fetchable resource. |
+| research_source | ref | A free-form reference describing the new method. The caller can pass anything that identifies the content — a local file path, any URL (blog post, arXiv, docs, Hugging Face page, …), a git repository, a Kaggle link, a paper ID, or **a plain text idea** describing the approach to try. Do not reject unusual values; investigate and fetch whatever was given, or, for pure text ideas, save the text verbatim. |
 | current_notebook | path | Path to the current baseline .ipynb |
 | current_data | path | Path to the current dataset (file or directory) |
 | experiments_directory | path | The directory (inside the workspace) where experiment folders live (e.g. `./experiments`). |
@@ -33,17 +33,18 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
 
    If `current_data` is a code-based download (e.g. `fetch_ucirepo(id=2)`), leave `current_data/` empty and record the download spec in `log.json`'s metadata.
 
-3. **Materialize the research source.** Detect the kind of `{research_source}` and save a local copy inside the experiment folder:
+3. **Materialize the research source.** `{research_source}` can be anything — a local file, a URL of any kind, a git or Kaggle link, an arXiv / paper ID, a Hugging Face page, **or a plain text idea** describing the method to try. Your job is to bring its content into the experiment folder using whatever tool fits:
 
-   | Kind | Detection | Command / action | Local path |
-   |---|---|---|---|
-   | Local PDF | existing path, `.pdf` extension | `cp {research_source} experiments/{research_name}/research.pdf` | `research.pdf` |
-   | Other local file | existing path, non-PDF (`.md`, `.html`, `.txt`, `.ipynb`, …) | `cp {research_source} experiments/{research_name}/research_source.{ext}` | `research_source.{ext}` |
-   | Git repository | `git@…`, ends in `.git`, or known git host (`github.com`, `gitlab.com`, `bitbucket.org`, …) | `git clone --depth 1 {research_source} experiments/{research_name}/research_source/` | `research_source/` |
-   | Kaggle notebook | `https://www.kaggle.com/code/<user>/<slug>` (or legacy `/kernels/…`) | if the Kaggle CLI is installed and authenticated: `kaggle kernels pull <user>/<slug> -p experiments/{research_name}/research_source/`. Otherwise fall back to fetching the page HTML. | `research_source/` |
-   | Kaggle dataset | `https://www.kaggle.com/datasets/<user>/<slug>` | if the Kaggle CLI is installed and authenticated: `kaggle datasets download -d <user>/<slug> -p experiments/{research_name}/research_source/ --unzip`. Otherwise save the page HTML. | `research_source/` |
-   | Web URL | `http(s)://` and not matched above | fetch the page (e.g. `curl -L -o research_source.html {research_source}`). If the URL clearly points at a PDF (e.g. arXiv `/pdf/...` link), save as `research.pdf`. Optionally also save a cleaned Markdown version as `research_source.md`. | `research_source.html` (or `research.pdf` / `research_source.md`) |
-   | Other | fallback | fetch and save a readable local copy; document the choice in `log.json.metadata` | as chosen |
+   - **Investigate first.** Check if the value is a path on disk (`ls` / `test -e`); if it looks like a URL, poke it with `curl -I`; look at the hostname; read any hint in the value itself. If the value does not look like a path or URL at all, treat it as a **text idea** (see below). Do not rely on a fixed detection list.
+   - **Retrievable source** → fetch it with the most appropriate tool: `cp`, `git clone --depth 1`, `curl -L` / `wget`, `kaggle kernels pull …` / `kaggle datasets download …`, `huggingface-cli`, an arXiv PDF helper, Python downloaders, or anything else available. Install a missing CLI with `pip install` / `uv pip install` if it is the right tool for this source.
+   - **Text idea** → do not fabricate a paper or URL. Save the description verbatim to `experiments/{research_name}/research_source.md` (optionally with a leading `# Idea` heading) and let Phase 2 turn it into a concrete implementation plan.
+   - **Pick a sensible local name** based on what you actually produced:
+     - A single PDF → `experiments/{research_name}/research.pdf`
+     - Any other single file (including a text idea) → `experiments/{research_name}/research_source.{ext}` (`.md` for ideas; preserve the real extension for files you copied)
+     - Multiple files or a cloned repo / dataset → `experiments/{research_name}/research_source/` (a directory)
+     - A fetched HTML page → `research_source.html`, optionally with a cleaned `research_source.md` and/or a linked `research.pdf`
+   - **Choose your own `research_source_kind` label** to describe what you did (e.g. `pdf`, `file`, `git`, `kaggle_notebook`, `kaggle_dataset`, `arxiv`, `huggingface_model`, `html`, `idea`, `other`). This label is just for observability — there is no closed enum.
+   - **If fetching fails**, try an alternative (different CLI, raw HTML fallback, `curl` instead of a specialized tool). Only after genuine failure, log the attempts in `log.json`, mark the experiment `FAILED`, and explain what you tried in `result.json.explanation`. A text idea can never "fail to fetch" — it is always saved verbatim.
 
    Let `research_source_local` be whichever local path you produced. Use that path for Phase 2 onwards — never re-fetch.
 
@@ -57,7 +58,7 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
        "original_data":          "{current_data}",
        "research_source":        "{research_source_local}",
        "research_source_origin": "{research_source}",
-       "research_source_kind":   "pdf | file | git | kaggle_notebook | kaggle_dataset | web | other"
+       "research_source_kind":   "a short label you pick, e.g. pdf, file, git, kaggle_notebook, kaggle_dataset, arxiv, huggingface_model, html, idea, other"
      },
      "phases": []
    }

--- a/prebuilt_autonomous_agents/applied_scientist/skills/research/SKILL.md
+++ b/prebuilt_autonomous_agents/applied_scientist/skills/research/SKILL.md
@@ -11,15 +11,15 @@ Phase 2 — after the current implementation has been analyzed.
 |-----------|------|-------------|
 | experiment_path | path | `experiments/{research_name}/` |
 
-The research source was materialized into `{experiment_path}` during Phase 0. Its local path is recorded in `{experiment_path}/log.json` under `metadata.research_source`, and its kind (`pdf`, `file`, `git`, `kaggle_notebook`, `kaggle_dataset`, `web`, `other`) under `metadata.research_source_kind`. Expected layouts:
+The research source was materialized into `{experiment_path}` during Phase 0. Its local path is recorded in `{experiment_path}/log.json` under `metadata.research_source`, and a short descriptive label Phase 0 chose is under `metadata.research_source_kind`. The label is free-form (common values: `pdf`, `file`, `git`, `kaggle_notebook`, `kaggle_dataset`, `arxiv`, `huggingface_model`, `html`, `idea`, `other`), but treat it as a hint only — always follow the actual path in `metadata.research_source`.
 
-- `pdf` → `{experiment_path}/research.pdf`
-- `file` → `{experiment_path}/research_source.{ext}` (Markdown, HTML, `.ipynb`, text, …)
-- `git` → `{experiment_path}/research_source/` (cloned repository — read `README*`, `docs/`, the top-level code, and any papers/notebooks inside)
-- `kaggle_notebook` → `{experiment_path}/research_source/` (pulled Kaggle kernel — read the `.ipynb` and any accompanying metadata; fall back to the saved HTML if the CLI was unavailable)
-- `kaggle_dataset` → `{experiment_path}/research_source/` (downloaded Kaggle dataset — read the dataset description / README and skim files to understand the data; fall back to the saved HTML if the CLI was unavailable)
-- `web` → `{experiment_path}/research_source.html` (and possibly `research_source.md` or `research.pdf`)
-- `other` → whatever Phase 0 saved (check `metadata.research_source`)
+Inspect that path and read whatever is there:
+
+- A single file (PDF, Markdown, HTML, `.ipynb`, text, …) → read it directly.
+- A directory → read the obvious entry points first (`README*`, `*.ipynb`, top-level notebooks or code, `docs/`, dataset descriptions), then skim the rest as needed.
+- A text **idea** (`research_source_kind == "idea"`, typically a short `research_source.md`) → read the user's description carefully and turn it into a concrete method plan. Pick a specific algorithm / library that matches the description, define the hyperparameters you will use, and document your interpretation explicitly in the Phase 2 log entry. If the idea is ambiguous, commit to a reasonable default and note the trade-off — do not invent a citation or claim the idea came from a paper.
+
+Do not try to re-fetch the source. If the content is insufficient, note what is missing in the Phase 2 log entry and proceed with the best analysis you can.
 
 ## Actions
 

--- a/prebuilt_autonomous_agents/applied_scientist/system_prompt.md
+++ b/prebuilt_autonomous_agents/applied_scientist/system_prompt.md
@@ -49,7 +49,7 @@ You will receive exactly five things:
 | Input | What It Is | Example |
 |---|---|---|
 | `research_name` | The exact folder name and JSON `"name"` to use for this experiment. **Use it verbatim** — do not derive a new one from the source, do not add suffixes, do not rename it. | `tabpfn_adult` |
-| `research_source` | Any reference that describes the new method. Accepted forms: local file (PDF, Markdown, HTML, .ipynb, text), web URL (blog post, arXiv, documentation), git repository URL (`https://…/repo.git` or `git@…`), Kaggle notebook or dataset page, or any other fetchable resource. | `example_1/tabpfn.pdf`, `https://arxiv.org/abs/2207.01848`, `https://github.com/automl/TabPFN`, `https://www.kaggle.com/code/<user>/<slug>` |
+| `research_source` | Anything that describes the new method. Accepted forms: local file or folder (PDF, Markdown, HTML, .ipynb, text), any URL (blog post, arXiv, documentation, Hugging Face, …), git repository URL, Kaggle notebook or dataset page, an arXiv / paper ID, **or a plain free-text idea** describing the approach to try. Do not reject unusual values; use your judgment to bring whatever is given into the experiment folder. | `example_1/tabpfn.pdf`, `https://arxiv.org/abs/2207.01848`, `https://github.com/automl/TabPFN`, `https://www.kaggle.com/code/<user>/<slug>`, `"swap XGBoost for CatBoost with ordered boosting"` |
 | `current_notebook` | A Jupyter notebook (.ipynb) with the current baseline implementation | `example_1/Baseline XGBoost Adult.ipynb` |
 | `current_data` | The dataset used by the current notebook (file or directory) | `example_1/data/` or downloaded via code in notebook |
 | `experiments_directory` | The directory inside your workspace where experiment folders live | `./experiments` |
@@ -58,19 +58,22 @@ The experiment folder is always `{experiments_directory}/{research_name}/`. If t
 
 ### Research source handling
 
-At Phase 0 you must inspect `research_source` and materialize it inside the experiment folder. The resulting path is what Phase 2 (`research` skill) reads from, and what you record in `log.json.metadata.research_source` and `result.json.file_locations.research_source`.
+`research_source` is intentionally free-form. Treat it as an opaque reference from the user and figure out yourself what it is and how to bring its content into the experiment folder — do not refuse it just because it does not match a known pattern. In particular, `research_source` may be a **free-text idea or method description** rather than anything retrievable; in that case the text itself *is* the research source.
 
-| Source type | How to detect | How to materialize | Local path |
-|---|---|---|---|
-| Local PDF | existing path ending in `.pdf` | `cp {research_source} experiments/{research_name}/research.pdf` | `research.pdf` |
-| Other local file (`.md`, `.html`, `.txt`, `.ipynb`, …) | existing path with a non-PDF extension | copy preserving extension | `research_source.{ext}` |
-| Git repository URL | starts with `git@`, ends in `.git`, or matches a known git host (`github.com`, `gitlab.com`, `bitbucket.org`, …) | `git clone --depth 1 {research_source} experiments/{research_name}/research_source/` | `research_source/` (directory) |
-| Kaggle notebook URL | `https://www.kaggle.com/code/<user>/<slug>` (or legacy `/kernels/…`) | pull the notebook with the Kaggle CLI when available (`kaggle kernels pull <user>/<slug> -p experiments/{research_name}/research_source/`), otherwise fetch the page HTML. Also save the rendered `.ipynb` if retrievable. | `research_source/` |
-| Kaggle dataset URL | `https://www.kaggle.com/datasets/<user>/<slug>` | download with `kaggle datasets download -d <user>/<slug> -p experiments/{research_name}/research_source/ --unzip` when available, otherwise save the page HTML. | `research_source/` |
-| Web URL (http/https, non-git, non-Kaggle) | URL scheme is `http` / `https` and not matched above | fetch the page; save raw HTML as `research_source.html` and, if useful, a cleaned Markdown version as `research_source.md`. For arXiv abstract URLs, also download the matching PDF to `research.pdf`. | `research_source.html` (+ optional `research.pdf` / `.md`) |
-| Anything else | fallback | do your best to fetch and save a readable local copy; document the choice in `log.json.metadata` | whatever you wrote |
+At Phase 0:
 
-In all cases, once materialized, use only the local path for Phase 2 onwards — never re-fetch during later phases.
+1. **Inspect the value.** Use any signal available to you — file existence on disk, URL structure, content sniffed with `curl -I` / `file`, known services, the user's own description, etc. Do not rely on a fixed list of prefixes. If the value does not look like a path or URL at all, treat it as an **idea / text description** (see step 3).
+2. **Fetch / clone / copy** a retrievable source into `experiments/{research_name}/` using whichever tool is appropriate: `cp`, `git clone`, `curl`, `wget`, `kaggle` CLI, `huggingface-cli`, language-specific downloaders, or the filesystem/shell tools at your disposal. Install missing CLIs if you need them.
+3. **If the source is a text idea**, do not try to fetch anything — just save the description itself to `experiments/{research_name}/research_source.md` verbatim (optionally with a leading `# Idea` heading). Use your Phase 2 work to flesh the idea out: pick a concrete method consistent with the description, decide the implementation plan, and document your interpretation in `log.json`. Do not invent a fake paper, author, or URL.
+4. **Pick a sensible local filename or folder** based on what you actually produced. Common outcomes (non-exhaustive — use your own judgment for anything novel):
+   - A PDF → `research.pdf`
+   - Any other single file (including a free-text idea) → `research_source.{ext}` (e.g. `research_source.md` for ideas)
+   - A cloned git repository or a bundle of files → `research_source/` (a directory)
+   - A fetched web page → `research_source.html` (+ optional `research_source.md` / `research.pdf` if that helps readability)
+5. **Record the outcome** in `log.json.metadata`: at minimum the original `research_source` value, the local path you produced, and a short free-form `research_source_kind` label you picked yourself (e.g. `"pdf"`, `"git"`, `"kaggle_notebook"`, `"html"`, `"arxiv"`, `"huggingface_model"`, `"idea"`, …). This label is for observability — there is no closed enum.
+6. **Fail loudly only after trying.** If a retrievable source genuinely cannot be fetched (404, auth required, unsupported scheme), log the attempt(s) in `log.json`, mark the experiment `FAILED`, and explain in `result.json.explanation` what you tried. A text idea can never "fail to fetch" — it is always saved verbatim.
+
+Once materialized, use only the local path for Phase 2 onwards — never re-fetch during later phases.
 
 ---
 
@@ -146,7 +149,7 @@ experiments/
 - Create `experiments/{research_name}/` directory
 - COPY the current notebook → `experiments/{research_name}/current.ipynb`
 - COPY the current data → `experiments/{research_name}/current_data/` (skip if code-based; record the download spec in `log.json`)
-- MATERIALIZE the research source into the experiment folder using the table above (PDF → `research.pdf`; other local file → `research_source.{ext}`; git repo → `research_source/`; Kaggle notebook or dataset → `research_source/`; generic web URL → `research_source.html` + optional extras). Record the chosen local path as `metadata.research_source` in `log.json`.
+- MATERIALIZE the research source into the experiment folder using the guidance in **Research source handling** above. Figure out what the value is (path, URL, git, Kaggle, arXiv, Hugging Face, …), fetch it with whichever tool fits, and save it under a sensible local name (`research.pdf`, `research_source.{ext}`, or `research_source/`). Record the resulting local path, the original value, and your chosen `research_source_kind` label in `log.json.metadata`.
 - Initialize `experiments/{research_name}/log.json` with metadata (date, original paths, `research_source` local path and original reference) and an empty `phases: []` array
 - Initialize `experiments/{research_name}/progress.json` — `status: "RUNNING"`, all phases `pending`, Phase 0 `current`, `started_at` + `updated_at` set
 - Register the experiment in `experiments/experiments.json` with `status: "in_progress"`

--- a/src/upsonic/prebuilt/__init__.py
+++ b/src/upsonic/prebuilt/__init__.py
@@ -13,11 +13,14 @@ Usage:
     scientist = AppliedScientist(model="openai/gpt-4o", workspace="./ws")
     exp = scientist.new_experiment(
         name="tabpfn_adult",
-        research_source="example_1/tabpfn.pdf",          # PDF, web URL, git repo, …
+        # Anything: local path, URL, git / Kaggle / arXiv / HF link,
+        # or a free-text idea like "swap XGBoost for CatBoost".
+        research_source="example_1/tabpfn.pdf",
         current_notebook="example_1/baseline.ipynb",
         current_data="downloaded in notebook (ucimlrepo, id=2)",
-        experiments_directory="./experiments",
-        inputs=["example_1/"],
+        # `experiments_directory` and `inputs` are both optional —
+        # experiments_directory defaults to "./experiments" and inputs is
+        # auto-derived from the arguments above.
     )
     exp.run()
     ```

--- a/src/upsonic/prebuilt/upsonic_prebuilt_agents.py
+++ b/src/upsonic/prebuilt/upsonic_prebuilt_agents.py
@@ -23,6 +23,45 @@ if TYPE_CHECKING:
 
 
 # --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _auto_inputs(*candidates: str) -> List[str]:
+    """
+    Derive a sandbox inputs list from free-form user arguments.
+
+    A candidate is kept when it happens to point at an existing local file
+    or directory (after ``~`` expansion). Everything else — URLs, git or
+    Kaggle references, arXiv links, descriptive text, anything novel — is
+    silently skipped and left for the agent's own skill to fetch at run
+    time. No scheme sniffing, no hardcoded remote prefixes; the existence
+    check on disk is the sole gate. Duplicates (by resolved path) are
+    removed while preserving the original order.
+    """
+    out: List[str] = []
+    seen: set = set()
+    for raw in candidates:
+        if not isinstance(raw, str):
+            continue
+        value = raw.strip()
+        if not value:
+            continue
+        try:
+            path = Path(value).expanduser()
+            if not path.exists():
+                continue
+            key = str(path.resolve())
+        except (OSError, ValueError):
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(value)
+    return out
+
+
+# --------------------------------------------------------------------------- #
 # Experiment — the "about to run / running / finished run" object
 # --------------------------------------------------------------------------- #
 
@@ -974,7 +1013,7 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         *,
         model: Union[str, "Model"] = "openai/gpt-4o",
         workspace: Optional[str] = None,
-        experiments_directory: str = "experiments",
+        experiments_directory: str = "./experiments",
         **kwargs: Any,
     ) -> None:
         kwargs.pop("agent_repo", None)
@@ -1008,16 +1047,30 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         verbatim — no derivation from the source title, no suffixes — so
         ``scientist.experiments[name]`` always points at this run.
 
-        ``research_source`` is the material describing the new method. It can
-        be a local PDF path, a web page / blog post URL, a git repository URL,
-        or any other reference the agent can fetch and read (e.g. a Markdown
-        or HTML file path, an arXiv link). The agent detects the source type
-        and materializes it under ``experiments/{research_name}/`` before
-        reading it.
+        ``research_source`` is intentionally free-form. It can be a local
+        path (PDF, Markdown, HTML, `.ipynb`, text, a folder), any URL (blog
+        post, arXiv, documentation, Hugging Face page, …), a git or Kaggle
+        link, an arXiv/paper ID, or just a free-text idea / description of
+        the method you want to try ("use a CatBoost classifier with ordered
+        boosting on the same features", "try Mamba-style state-space layers
+        instead of attention", …). The agent inspects the value at Phase 0,
+        materializes whatever content it can retrieve under
+        ``experiments/{research_name}/``, and for pure-text ideas records
+        the description itself as the source.
 
-        ``experiments_directory`` defaults to the value supplied at
-        construction (``"experiments"`` unless overridden). It is always
-        relative to the agent's workspace.
+        ``experiments_directory`` is optional; it defaults to the value
+        supplied at construction (``"./experiments"`` unless overridden) and
+        is always resolved relative to the agent's workspace.
+
+        ``inputs`` is the list of local paths copied into the agent's
+        workspace so it can read them. When left as ``None`` (the default),
+        it is auto-derived from ``research_source``, ``current_notebook``,
+        and ``current_data``: each value that refers to an existing local
+        file or directory is added. Values that are URLs, git / Kaggle
+        links, or free-text descriptions (e.g. ``"downloaded in notebook
+        (ucimlrepo, id=2)"``) are ignored — the agent handles those at run
+        time. Pass an explicit list to override the auto-derivation; pass
+        ``[]`` to disable copying entirely.
         """
         if not isinstance(name, str) or not name.strip():
             raise ValueError(
@@ -1026,6 +1079,11 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         exp_dir = experiments_directory or self._experiments_directory
         if experiments_directory is not None:
             self._experiments_directory = experiments_directory
+        resolved_inputs = (
+            inputs
+            if inputs is not None
+            else _auto_inputs(research_source, current_notebook, current_data)
+        )
         return Experiment(
             agent=self,
             name=name,
@@ -1036,7 +1094,7 @@ class AppliedScientist(PrebuiltAutonomousAgent):
                 "current_data": current_data,
                 "experiments_directory": exp_dir,
             },
-            inputs=inputs,
+            inputs=resolved_inputs,
         )
 
     @property


### PR DESCRIPTION
research_source is now fully free-form on the Python side: no scheme sniffing, no hardcoded remote-prefix list. The agent-side skill inspects whatever value it receives (local path, URL, git / Kaggle / arXiv / Hugging Face link, or a plain-text idea) and uses whichever tool fits to bring the content into the experiment folder. Free-text ideas are saved verbatim to research_source.md and Phase 2 turns them into a concrete method plan — no fabricated citations.

new_experiment(...) auto-derives `inputs` from research_source / current_notebook / current_data: any value that points at an existing local path is copied into the workspace. URLs, remote references, and descriptive text are left alone.

experiments_directory is now optional and defaults to "./experiments".