### PR TITLE
chore: New Version 0.76.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,6 @@ cython_debug/
 
 .claude
 .serena
+
+# Internal release-note drafts (not committed)
+RELEASE_NOTES_v*.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "upsonic"
-version = "0.76.1"
+version = "0.76.2"
 description = "Agent Framework For Fintech"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -8824,7 +8824,7 @@ wheels = [
 
 [[package]]
 name = "upsonic"
-version = "0.76.1"
+version = "0.76.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bump pyproject.toml + uv.lock, fast-forward the Docs submodule pointer to the v0.76.2 docs push, and start ignoring internal RELEASE_NOTES_v*.md drafts.