### PR TITLE
feat: current_data optional, agent infers data source from notebook

### DIFF
--- a/prebuilt_autonomous_agents/applied_scientist/skills/experiment_management/SKILL.md
+++ b/prebuilt_autonomous_agents/applied_scientist/skills/experiment_management/SKILL.md
@@ -13,7 +13,7 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
 | research_name | string | The experiment name **as given by the caller**. Use it verbatim — do not rename it, do not re-derive it from the source title. |
 | research_source | ref | A free-form reference describing the new method. The caller can pass anything that identifies the content — a local file path, any URL (blog post, arXiv, docs, Hugging Face page, …), a git repository, a Kaggle link, a paper ID, or **a plain text idea** describing the approach to try. Do not reject unusual values; investigate and fetch whatever was given, or, for pure text ideas, save the text verbatim. |
 | current_notebook | path | Path to the current baseline .ipynb |
-| current_data | path | Path to the current dataset (file or directory) |
+| current_data | ref \| placeholder | Path to the current dataset (file or directory), a short description of how the notebook loads data, **or** the literal placeholder `"(not provided — infer it from the current notebook's data-loading cells)"`. When you see that placeholder, read the current notebook yourself and infer the source from its data-loading cells; do not ask the user. |
 | experiments_directory | path | The directory (inside the workspace) where experiment folders live (e.g. `./experiments`). |
 
 ## Actions
@@ -28,10 +28,15 @@ Set up and manage the experiment folder structure. This is Phase 0 — it runs b
 2. **Copy baseline files (NEVER move, NEVER modify originals):**
    ```bash
    cp {current_notebook} experiments/{research_name}/current.ipynb
+   # Only when current_data is a real path on disk:
    cp -r {current_data}  experiments/{research_name}/current_data/
    ```
 
-   If `current_data` is a code-based download (e.g. `fetch_ucirepo(id=2)`), leave `current_data/` empty and record the download spec in `log.json`'s metadata.
+   Resolve `{current_data}` as follows before copying:
+
+   - **Real local path** (file or directory that exists on disk) → `cp` / `cp -r` it into `current_data/`.
+   - **Short description of a code-based download** (e.g. `"downloaded in notebook (ucimlrepo, id=2)"`) → leave `current_data/` empty and record the description verbatim in `log.json.metadata.original_data`.
+   - **Placeholder `"(not provided — infer it from the current notebook's data-loading cells)"`** → open `current.ipynb` yourself, scan for data-loading cells (`pd.read_csv`, `fetch_openml`, `fetch_ucirepo`, `load_dataset`, `kaggle.api...`, `urllib`/`requests` downloads, `np.load`, local paths, …), write down the exact loader you found as `log.json.metadata.original_data`, and make sure Phase 4's `new.ipynb` uses the same loader. Do not ask the user for clarification — do the investigation yourself.
 
 3. **Materialize the research source.** `{research_source}` can be anything — a local file, a URL of any kind, a git or Kaggle link, an arXiv / paper ID, a Hugging Face page, **or a plain text idea** describing the method to try. Your job is to bring its content into the experiment folder using whatever tool fits:
 

--- a/prebuilt_autonomous_agents/applied_scientist/system_prompt.md
+++ b/prebuilt_autonomous_agents/applied_scientist/system_prompt.md
@@ -51,10 +51,12 @@ You will receive exactly five things:
 | `research_name` | The exact folder name and JSON `"name"` to use for this experiment. **Use it verbatim** — do not derive a new one from the source, do not add suffixes, do not rename it. | `tabpfn_adult` |
 | `research_source` | Anything that describes the new method. Accepted forms: local file or folder (PDF, Markdown, HTML, .ipynb, text), any URL (blog post, arXiv, documentation, Hugging Face, …), git repository URL, Kaggle notebook or dataset page, an arXiv / paper ID, **or a plain free-text idea** describing the approach to try. Do not reject unusual values; use your judgment to bring whatever is given into the experiment folder. | `example_1/tabpfn.pdf`, `https://arxiv.org/abs/2207.01848`, `https://github.com/automl/TabPFN`, `https://www.kaggle.com/code/<user>/<slug>`, `"swap XGBoost for CatBoost with ordered boosting"` |
 | `current_notebook` | A Jupyter notebook (.ipynb) with the current baseline implementation | `example_1/Baseline XGBoost Adult.ipynb` |
-| `current_data` | The dataset used by the current notebook (file or directory) | `example_1/data/` or downloaded via code in notebook |
+| `current_data` | The dataset used by the current notebook. Can be a file or directory path, a short description of how the notebook loads data, **or the placeholder `"(not provided — infer it from the current notebook's data-loading cells)"`** when the caller did not specify it. | `example_1/data/`, `"downloaded in notebook (ucimlrepo, id=2)"`, or the "not provided" placeholder |
 | `experiments_directory` | The directory inside your workspace where experiment folders live | `./experiments` |
 
 The experiment folder is always `{experiments_directory}/{research_name}/`. If the current notebook downloads its data programmatically (e.g., from `ucimlrepo` or `sklearn.datasets`), record that in `log.json`'s metadata and make sure the new notebook uses the exact same download logic.
+
+**When `current_data` is the "not provided" placeholder**, do not ask the user — read the current notebook yourself at Phase 0 / Phase 1 and infer the data source from its cells: identify the loader (`pandas.read_csv(...)`, `fetch_openml(...)`, `fetch_ucirepo(id=...)`, `load_dataset(...)`, a URL download, a local path, …), record exactly what you found under `log.json.metadata.original_data` (so the record stays complete), and make sure the new notebook uses that same loader so the comparison is fair.
 
 ### Research source handling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "upsonic"
-version = "0.76.2"
+version = "0.76.3"
 description = "Agent Framework For Fintech"
 readme = "README.md"
 authors = [

--- a/src/upsonic/prebuilt/__init__.py
+++ b/src/upsonic/prebuilt/__init__.py
@@ -17,10 +17,10 @@ Usage:
         # or a free-text idea like "swap XGBoost for CatBoost".
         research_source="example_1/tabpfn.pdf",
         current_notebook="example_1/baseline.ipynb",
-        current_data="downloaded in notebook (ucimlrepo, id=2)",
-        # `experiments_directory` and `inputs` are both optional —
-        # experiments_directory defaults to "./experiments" and inputs is
-        # auto-derived from the arguments above.
+        # `current_data`, `experiments_directory`, and `inputs` are all
+        # optional. When `current_data` is omitted, the agent reads the
+        # notebook itself and infers the data source from its loading
+        # cells. `experiments_directory` defaults to "./experiments".
     )
     exp.run()
     ```

--- a/src/upsonic/prebuilt/upsonic_prebuilt_agents.py
+++ b/src/upsonic/prebuilt/upsonic_prebuilt_agents.py
@@ -1033,7 +1033,7 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         *,
         research_source: str,
         current_notebook: str,
-        current_data: str,
+        current_data: Optional[str] = None,
         experiments_directory: Optional[str] = None,
         inputs: Optional[List[str]] = None,
     ) -> Experiment:
@@ -1058,6 +1058,15 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         ``experiments/{research_name}/``, and for pure-text ideas records
         the description itself as the source.
 
+        ``current_data`` is optional. If left as ``None`` (the default),
+        the agent is told to infer the data source by reading the current
+        notebook itself — locating the cells that load or download the
+        dataset and using that as the single source of truth for both the
+        baseline and the new implementation. Pass a value only when you
+        want to pin the data source explicitly (a path like ``./data/``,
+        a short description such as ``"downloaded in notebook (ucimlrepo,
+        id=2)"``, etc.).
+
         ``experiments_directory`` is optional; it defaults to the value
         supplied at construction (``"./experiments"`` unless overridden) and
         is always resolved relative to the agent's workspace.
@@ -1079,10 +1088,15 @@ class AppliedScientist(PrebuiltAutonomousAgent):
         exp_dir = experiments_directory or self._experiments_directory
         if experiments_directory is not None:
             self._experiments_directory = experiments_directory
+        template_current_data = (
+            current_data
+            if current_data is not None
+            else "(not provided — infer it from the current notebook's data-loading cells)"
+        )
         resolved_inputs = (
             inputs
             if inputs is not None
-            else _auto_inputs(research_source, current_notebook, current_data)
+            else _auto_inputs(research_source, current_notebook, current_data or "")
         )
         return Experiment(
             agent=self,
@@ -1091,7 +1105,7 @@ class AppliedScientist(PrebuiltAutonomousAgent):
                 "research_name": name,
                 "research_source": research_source,
                 "current_notebook": current_notebook,
-                "current_data": current_data,
+                "current_data": template_current_data,
                 "experiments_directory": exp_dir,
             },
             inputs=resolved_inputs,

--- a/uv.lock
+++ b/uv.lock
@@ -8824,7 +8824,7 @@ wheels = [
 
 [[package]]
 name = "upsonic"
-version = "0.76.2"
+version = "0.76.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
`scientist.new_experiment(..., current_data=None)` is now the default. When current_data is omitted the agent opens the current notebook itself at Phase 0 / Phase 1, locates the data-loading cells (`pd.read_csv`, `fetch_openml`, `fetch_ucirepo`, `load_dataset`, `kaggle` downloads, local paths, …), records what it found in `log.json.metadata.original_data`, and reuses the same loader in Phase 4's new.ipynb so the comparison stays fair.

Also bumps pyproject.toml and uv.lock to 0.76.3 as part of the same change set, per the one-PR release convention.