### PR TITLE
chore: make mcp and fastmcp optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "sentry-sdk[opentelemetry]>=2.35.0",
     "toml>=0.10.2",
     "uv>=0.5.20",
-    "mcp[cli]>=1.26.0",
     "python-dotenv>=1.0.1",
     "uvicorn>=0.34.0",
     "nest-asyncio>=1.6.0",
@@ -39,10 +38,13 @@ dependencies = [
     "genai-prices>=0.0.38",
     "protobuf>=5.27.2,<6.0.0",
     "cloudpickle>=3.1.2",
-    "fastmcp>=2.14.5",
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "mcp[cli]>=1.26.0",
+    "fastmcp>=2.14.5",
+]
 chroma = [
     "chromadb>=1.0.20; python_version < '3.14'",
 ]

--- a/src/upsonic/agent/agent.py
+++ b/src/upsonic/agent/agent.py
@@ -4248,7 +4248,15 @@ class Agent(BaseAgent):
         Returns:
             A :class:`fastmcp.FastMCP` server instance ready to ``.run()``.
         """
-        from fastmcp import FastMCP as _FastMCP
+        try:
+            from fastmcp import FastMCP as _FastMCP  # type: ignore[import-not-found]
+        except ImportError:
+            from upsonic.utils.printing import import_error
+            import_error(
+                package_name="fastmcp",
+                install_command="pip install 'upsonic[mcp]'",
+                feature_name="Agent.as_mcp() (expose agent as an MCP server)",
+            )
 
         server_name: str = name or self.name or "Upsonic Agent"
         server: _FastMCP = _FastMCP(server_name)

--- a/src/upsonic/team/team.py
+++ b/src/upsonic/team/team.py
@@ -689,7 +689,15 @@ class Team:
         Returns:
             A :class:`fastmcp.FastMCP` server instance ready to ``.run()``.
         """
-        from fastmcp import FastMCP as _FastMCP
+        try:
+            from fastmcp import FastMCP as _FastMCP  # type: ignore[import-not-found]
+        except ImportError:
+            from upsonic.utils.printing import import_error
+            import_error(
+                package_name="fastmcp",
+                install_command="pip install 'upsonic[mcp]'",
+                feature_name="Team.as_mcp() (expose team as an MCP server)",
+            )
 
         server_name: str = name or self.name or "Upsonic Team"
         server: _FastMCP = _FastMCP(server_name)

--- a/src/upsonic/tools/mcp.py
+++ b/src/upsonic/tools/mcp.py
@@ -17,18 +17,49 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import httpx
-from mcp import types as mcp_types
-from mcp.client.session import ClientSession
-from mcp.client.sse import sse_client
-from mcp.client.stdio import StdioServerParameters, stdio_client
 
 from upsonic.tools.base import Tool, ToolMetadata
 
+# The `mcp` SDK is an optional extra (install with `pip install upsonic[mcp]`).
+# We let the module import succeed without it so that downstream isinstance
+# checks (e.g. processor.py) keep working; instantiating MCPHandler / MultiMCPHandler
+# without the SDK raises a clear ImportError instead.
 try:
-    from mcp.client.streamable_http import streamable_http_client
-    HAS_STREAMABLE_HTTP = True
+    from mcp import types as mcp_types  # type: ignore[import-not-found]
+    from mcp.client.session import ClientSession  # type: ignore[import-not-found]
+    from mcp.client.sse import sse_client  # type: ignore[import-not-found]
+    from mcp.client.stdio import StdioServerParameters, stdio_client  # type: ignore[import-not-found]
+    _MCP_AVAILABLE = True
 except ImportError:
+    _MCP_AVAILABLE = False
+    mcp_types = None  # type: ignore[assignment]
+    ClientSession = None  # type: ignore[assignment,misc]
+    sse_client = None  # type: ignore[assignment]
+    stdio_client = None  # type: ignore[assignment]
+    StdioServerParameters = None  # type: ignore[assignment,misc]
+
+if _MCP_AVAILABLE:
+    try:
+        from mcp.client.streamable_http import streamable_http_client  # type: ignore[import-not-found]
+        HAS_STREAMABLE_HTTP = True
+    except ImportError:
+        HAS_STREAMABLE_HTTP = False
+        streamable_http_client = None  # type: ignore[assignment]
+else:
     HAS_STREAMABLE_HTTP = False
+    streamable_http_client = None  # type: ignore[assignment]
+
+
+def _require_mcp() -> None:
+    """Raise a friendly ImportError if the optional `mcp` SDK is missing."""
+    if _MCP_AVAILABLE:
+        return
+    from upsonic.utils.printing import import_error
+    import_error(
+        package_name="mcp",
+        install_command="pip install 'upsonic[mcp]'",
+        feature_name="MCP (Model Context Protocol) tool integration",
+    )
 
 
 _MCP_SECURITY_WARNING_EMITTED = False
@@ -235,6 +266,7 @@ class MCPHandler:
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "MCPHandler":
+        _require_mcp()
         _emit_mcp_security_warning()
         return super().__new__(cls)
 
@@ -779,6 +811,7 @@ class MultiMCPHandler:
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "MultiMCPHandler":
+        _require_mcp()
         _emit_mcp_security_warning()
         return super().__new__(cls)
 

--- a/uv.lock
+++ b/uv.lock
@@ -8830,11 +8830,9 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "cloudpickle" },
-    { name = "fastmcp" },
     { name = "genai-prices" },
     { name = "griffe" },
     { name = "httpx" },
-    { name = "mcp", extra = ["cli"] },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "protobuf" },
@@ -8953,6 +8951,10 @@ mail-interface = [
 markdown-loader = [
     { name = "markdown-it-py" },
     { name = "python-frontmatter" },
+]
+mcp = [
+    { name = "fastmcp" },
+    { name = "mcp", extra = ["cli"] },
 ]
 mem0-storage = [
     { name = "mem0ai" },
@@ -9161,7 +9163,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'slack-interface'", specifier = ">=0.128.0" },
     { name = "fastapi", marker = "extra == 'web'" },
     { name = "fastembed", marker = "python_full_version < '3.14' and extra == 'embeddings'", specifier = ">=0.7.3" },
-    { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.14.5" },
     { name = "firecrawl-py", marker = "extra == 'custom-tools'", specifier = ">=4.14.1" },
     { name = "genai-prices", specifier = ">=0.0.38" },
     { name = "genai-prices", marker = "extra == 'tools'", specifier = ">=0.0.29" },
@@ -9189,7 +9191,7 @@ requires-dist = [
     { name = "lxml", marker = "extra == 'xml-loader'", specifier = ">=4.9.1" },
     { name = "markdown-it-py", marker = "extra == 'loaders'", specifier = ">=4.0.0" },
     { name = "markdown-it-py", marker = "extra == 'markdown-loader'", specifier = ">=4.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.26.0" },
     { name = "mem0ai", marker = "extra == 'mem0-storage'", specifier = ">=0.1.116" },
     { name = "mistralai", marker = "extra == 'models'", specifier = ">=1.9.11" },
     { name = "motor", marker = "extra == 'mongo-storage'", specifier = ">=3.7.1" },
@@ -9291,7 +9293,7 @@ requires-dist = [
     { name = "xai-sdk", marker = "extra == 'models'", specifier = ">=1.4.0" },
     { name = "yfinance", marker = "extra == 'tools'", specifier = ">=0.2.66" },
 ]
-provides-extras = ["chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
+provides-extras = ["mcp", "chroma", "qdrant", "milvus", "weaviate", "pinecone", "faiss", "pgvector", "supermemory", "vectordb", "sqlite-storage", "redis-storage", "postgres-storage", "mongo-storage", "mem0-storage", "storage", "models", "embeddings", "csv-loader", "docling-loader", "docx-loader", "html-loader", "json-loader", "markdown-loader", "pdf-loader", "pdfplumber-loader", "pymupdf-loader", "text-loader", "xml-loader", "yaml-loader", "loaders", "tools", "web", "ocr", "custom-tools", "apify-tool", "crawlee-browser", "gmail-interface", "safety-engine", "slack-interface", "mail-interface", "discord-interface", "otel", "langfuse", "gmail-tool"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Moves `mcp[cli]` and `fastmcp` out of required dependencies into a new `[mcp]` optional extra. `tools/mcp.py` imports are guarded so the module loads without the SDK; `MCPHandler`/`MultiMCPHandler` and `Agent`/`Team.as_mcp()` raise a clear `ImportError` pointing at `pip install 'upsonic[mcp]'` when used without the extra.